### PR TITLE
feat: use graphback 2.0

### DIFF
--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -22,6 +22,14 @@ extensions:
             subUpdate: false
             subDelete: false
             disableGen: false
+        generator: 
+            resolvers: 
+                format: 'ts'
+                types: 
+                    typesImportStatement: 'import { Resolvers } from "../../generated-types"'
+                    resolverType: 'Resolvers'
+            schema: 
+                format: 'ts',
         folders:
             model: ./model
             resolvers: ./server/src/resolvers

--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -26,8 +26,8 @@ extensions:
             resolvers: 
                 format: 'ts'
                 types: 
-                    typesImportStatement: 'import { Resolvers } from "../../generated-types"'
-                    resolverType: 'Resolvers'
+                    resolverRootLocation: '../../generated-types'
+                    resolverRootType: 'Resolvers'
             schema: 
                 format: 'ts',
         folders:

--- a/server/package.json
+++ b/server/package.json
@@ -1,28 +1,29 @@
 {
-    "private": true,
-    "name": "server",
-    "version": "4.0.0",
-    "scripts": {
-      "develop": "ts-node-dev src/index.ts",
-      "start": "ts-node src/index.ts"
-    },
-    "dependencies": {
-        "@types/cors": "2.8.6",
-        "@types/express": "4.17.2",
-        "@types/node": "12.12.8",
-        "cors": "2.8.5",
-        "express": "4.17.1",
-        "express-graphql": "0.9.0",
-        "graphql": "14.5.8",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tag": "2.10.1",
-        "graphql-tools": "4.0.6",
-        "knex": "0.20.2",
-        "pg": "7.12.1",
-        "sqlite3": "4.1.0",
-        "subscriptions-transport-ws": "0.9.16",
-        "ts-node": "8.5.0",
-        "ts-node-dev": "1.0.0-pre.44",
-        "typescript": "3.7.2"
-    }
+  "private": true,
+  "name": "server",
+  "version": "4.0.0",
+  "scripts": {
+    "develop": "ts-node-dev src/index.ts",
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@graphback/runtime": "0.10.0-dev2",
+    "@types/cors": "2.8.6",
+    "@types/express": "4.17.2",
+    "@types/node": "12.12.5",
+    "apollo-server-express": "2.9.8",
+    "cors": "2.8.5",
+    "express": "4.17.1",
+    "graphql": "14.5.8",
+    "graphql-subscriptions": "1.1.0",
+    "graphql-tag": "2.10.1",
+    "graphql-tools": "4.0.6",
+    "knex": "0.20.2",
+    "pg": "7.12.1",
+    "sqlite3": "4.1.0",
+    "subscriptions-transport-ws": "0.9.16",
+    "ts-node": "8.5.0",
+    "ts-node-dev": "1.0.0-pre.44",
+    "typescript": "3.7.2"
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -20,8 +20,6 @@
     "graphql-tools": "4.0.6",
     "knex": "0.20.2",
     "pg": "7.12.1",
-    "sqlite3": "4.1.0",
-    "subscriptions-transport-ws": "0.9.16",
     "ts-node": "8.5.0",
     "ts-node-dev": "1.0.0-pre.44",
     "typescript": "3.7.2"

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@graphback/runtime": "0.10.0-dev2",
+    "@graphback/runtime": "0.10.0-rc2",
     "@types/cors": "2.8.6",
     "@types/express": "4.17.2",
     "@types/node": "12.12.5",

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -1,1 +1,4 @@
-export * from './generated';
+import gql from 'graphql-tag';
+import { schemaString } from './generated';
+
+export const typeDefs = gql`${schemaString}`;


### PR DESCRIPTION
Motivation

Graphback 2.0 introduces a robust generator engine along with the major improvements for performance and developer usability. This PR contains minimal changes required to get templates work with Graphback 2.0

Not to be merged without graphql-cli PR